### PR TITLE
ci: re-dispatch PR checks after Claude pushes autoupdate fixes

### DIFF
--- a/.github/workflows/autoupdate.yml
+++ b/.github/workflows/autoupdate.yml
@@ -148,7 +148,8 @@ jobs:
                 npm test
 
           Claude will leave a status comment on this PR when it finishes.
-          PR-checks will re-run on each new commit.
+          The Claude workflow re-dispatches PR-checks once it is done, so the
+          checks below reflect its pushed fixes.
           EOF
           )
           PR_URL=$(gh pr create \

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -41,7 +41,7 @@ jobs:
       pull-requests: write
       issues: write
       id-token: write
-      actions: read
+      actions: write
     steps:
       - name: Checkout repo
         uses: actions/checkout@v6
@@ -65,9 +65,9 @@ jobs:
           Run these commands and observe their exit codes via the Bash tool —
           not inferred:
 
-              npm run lint
-              npm run build
-              npm test
+                  npm run lint
+                  npm run build
+                  npm test
 
           Hard rules:
           - Run those commands yourself before every push. Do not push
@@ -79,7 +79,11 @@ jobs:
             defaults). Do NOT change product logic.
           - Do NOT bump the package version.
           - When all commands are green, push commits with your fixes
-            (if any). \`pr-checks\` will re-run automatically on each push.
+            (if any). Do NOT try to trigger \`pr-checks\` yourself: a push
+            made with \`GITHUB_TOKEN\` does not start a workflow run, and
+            the \`pull_request\` run it queues stays in \`action_required\`.
+            This workflow re-dispatches \`pr-checks\` for you after this
+            step finishes.
 
           ## MANDATORY final step
 
@@ -102,6 +106,7 @@ jobs:
             echo PROMPT_EOF
           } >> "$GITHUB_OUTPUT"
       - name: Run Claude Code
+        id: claude
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
@@ -109,3 +114,17 @@ jobs:
           prompt: ${{ steps.prep.outputs.prompt }}
           claude_args: |
             --allowedTools "Edit,Write,MultiEdit,Bash(git:*),Bash(gh:*),Bash(npm:*),Bash(npx:*),Bash(node:*),Bash(rm:*),Bash(mkdir:*),Bash(cat:*),Bash(ls:*),Bash(echo:*),Bash(grep:*),Bash(find:*),Bash(sed:*),Bash(awk:*),Bash(head:*),Bash(tail:*),Bash(diff:*),Bash(mv:*),Bash(cp:*),Bash(touch:*)"
+      # Claude pushes with GITHUB_TOKEN, so its push fires no `push` run and the
+      # `pull_request` run GitHub queues for it stays stuck in `action_required`.
+      # Dispatch the checks explicitly — `workflow_dispatch` is the only trigger
+      # that is not gated. Runs even if the step above failed, so the PR ends up
+      # with a red check instead of no checks at all.
+      - name: Re-dispatch PR checks on the branch Claude pushed to
+        if: always() && github.event_name == 'workflow_dispatch' && github.event.inputs.branch != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: ${{ github.event.inputs.branch }}
+        run: |
+          git fetch origin "$BRANCH"
+          echo "Dispatching checks for $BRANCH @ $(git rev-parse --short "origin/$BRANCH")"
+          gh workflow run pr-checks.yml --ref "$BRANCH" || true


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[x] CI related changes
[ ] Documentation content changes
[ ] Tests
[ ] Other
```

## Notes

Rolls out the workflow fix from `siarheidudko/claude#4`.

Across the sibling repos, autoupdate PRs that needed a Claude fix ended up with **zero check runs** and sat stuck. The fixes Claude pushed were correct; nothing ever ran CI on them:

1. Claude pushes with `GITHUB_TOKEN`, and a `GITHUB_TOKEN` push creates no workflow run, so `pr-checks`' `push:` trigger never fires.
2. The `pull_request` run GitHub *does* queue for that commit ends in `action_required` and never executes — hence no checks at all rather than a red one.
3. `autoupdate.yml` dispatched `pr-checks` exactly once, right after opening the PR, i.e. against the broken baseline before Claude's fix existed.

This repo's own autoupdate PR (#29) happened to need no Claude fix, so its single baseline dispatch already landed on the final commit and went green — it dodged the bug rather than being immune to it.

**Changes**

- `claude.yml` — new final step dispatching `pr-checks.yml` on `inputs.branch` after the Claude Code step (`workflow_dispatch` is the only ungated trigger). Guarded with `always()` so a failed Claude session leaves a red check instead of an empty list.
- `claude.yml` — `actions: read` → `actions: write`, required for `gh workflow run`.
- `autoupdate.yml` — PR body no longer claims checks re-run automatically on each push.

No product code touched; `build-and-deploy.yml` untouched. Backward compatible.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PfHHX2WrotHCt9djnk6tMZ)_